### PR TITLE
Add some dorks for PHP-based webapps and CMS frameworks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,6 @@ filename:sshd_config                            | OpenSSH server config
 filename:dhcpd.conf                             | DHCP service config
 filename:prod.exs NOT "prod.secret.exs"         | Phoenix prod configuration file
 filename:prod.secret.exs                        | Phoenix prod secret
+filename:configuration.php JConfig password     | Joomla configuration file
+filename:config.php dbpasswd                    | PHP application database password (e.g., phpBB forum software)
+path:sites databases password                   | Drupal website database credentials

--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -50,3 +50,6 @@ filename:sshd_config
 filename:dhcpd.conf
 filename:prod.exs NOT "prod.secret.exs"
 filename:prod.secret.exs
+filename:configuration.php JConfig password
+filename:config.php dbpasswd
+path:sites databases password


### PR DESCRIPTION
These dorks are useful for finding credentials of PHP-based webapps such as Drupal, Joomla, and phpBB, among others. They were written a little vaguely in order to find results that were similar but not exclusively the above CMS tools.