### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ pip install -r requirements.txt
 GH_USER  - Environment variable to specify github user
 GH_PWD   - Environment variable to specify password
 GH_TOKEN - Environment variable to specify github token
+GH_URL   - Environment variable to specify GitHub Enterprise base URL
 ```
 
 Some example usages are listed below:
@@ -31,6 +32,8 @@ python github-dork.py -u dev-nepal                                      # search
 GH_USER=techgaun GH_PWD=<mypass> python github-dork.py -u dev-nepal     # search as authenticated user
 
 GH_TOKEN=<github_token> python github-dork.py -u dev-nepal              # search using auth token
+
+GH_URL=https://github.example.com python github-dork.py -u dev-nepal    # search a GitHub Enterprise instance
 ```
 
 #### Limitations

--- a/github-dork.py
+++ b/github-dork.py
@@ -13,8 +13,12 @@ from sys import stderr
 gh_user = os.getenv('GH_USER', None)
 gh_pass = os.getenv('GH_PWD', None)
 gh_token = os.getenv('GH_TOKEN', None)
+gh_url = os.getenv('GH_URL', None)
 
-gh = github.GitHub(username=gh_user, password=gh_pass, token=gh_token)
+if gh_url is None:
+    gh = github.GitHub(username=gh_user, password=gh_pass, token=gh_token)
+else:
+    gh = github.GitHubEnterprise(url=gh_url, username=gh_user, password=gh_pass, token=gh_token)
 
 def search_wrapper(gen):
     while True:


### PR DESCRIPTION
Allows you to set the GH_URL environment variable, which will cause
github-dork to connect to that URL instead of github.com.