### PR TITLE
Adding Rails secrets.yml dork

### DIFF
--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -72,3 +72,4 @@ filename:logins.json
 filename:CCCam.cfg
 msg nickserv identify filename:config
 filename:settings.py SECRET_KEY
+filename:secrets.yml password


### PR DESCRIPTION
Rails uses a file secrets.yml to hold API keys and passwords. This should never be in github repositories... but it often is. Adding this to the list.

### Please include all of the following fields when adding dorks/patterns
- Search URL: https://github.com/search?q=filename%3Asecrets.yml+password&type=Code
- Number of search results at time of PR: 8354
- Impact of data disclosed (see table below): Critical
- Description of data disclosed: usernames/passwords, Rails applications

| Icon/Name | Description                                                                                             | Examples                                                       |
|-----------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
❓ Unknown    | The impact of this data is highly variable or unknown)                                                 | N/A                                                                |
➖ Low      | This data will provide minimal access or mostly public information)                                     | Non-stored XSS, Limited scope + read-only API access           |
➕ Moderate | This data will provide some access or information                                                       | Stored XSS in some cases, read-only or limited write API access|
⚠️ High     | This data will provide single-user access or secret information)                                        | Usernames/passwords, OAuth tokens                              |
❗️ Critical   | This data will provide complete control, access to several users, or confidential/personal information | Credential database dumps, AWS keys
