### PR TITLE
Add telegram API token (Hacktoberfest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ filename:.remote-sync.json                      | Created by remote-sync for Ato
 filename:sftp.json path:.vscode                 | Created by vscode-sftp for VSCode, contains SFTP/SSH server details and credentails
 filename:sftp-config.json                       | Created by SFTP for Sublime Text, contains FTP/FTPS or SFTP/SSH server details and credentials
 filename:WebServers.xml                         | Created by Jetbrains IDEs, contains webserver credentials with encoded passwords ([not encrypted!](https://intellij-support.jetbrains.com/hc/en-us/community/posts/207074025/comments/207034775))
+"api_hash" "api_id"                             | Telegram API token

--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -80,4 +80,4 @@ filename:.remote-sync.json
 filename:sftp.json path:.vscode
 filename:WebServers.xml
 filename:jupyter_notebook_config.json
-
+"api_hash" "api_id"


### PR DESCRIPTION
- Search URL: https://github.com/search?q=%22api_hash%22+%22api_id%22
- Number of search results at time of PR: 70,305
- Impact of data disclosed: High
- Description of data disclosed: API token for telegram