### PR TITLE
Add Slack services (Hacktoberfest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ filename:.remote-sync.json                      | Created by remote-sync for Ato
 filename:sftp.json path:.vscode                 | Created by vscode-sftp for VSCode, contains SFTP/SSH server details and credentails
 filename:sftp-config.json                       | Created by SFTP for Sublime Text, contains FTP/FTPS or SFTP/SSH server details and credentials
 filename:WebServers.xml                         | Created by Jetbrains IDEs, contains webserver credentials with encoded passwords ([not encrypted!](https://intellij-support.jetbrains.com/hc/en-us/community/posts/207074025/comments/207034775))
+"https://hooks.slack.com/services/"             | Slack services URL often have secret API token as a suffix

--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -80,4 +80,4 @@ filename:.remote-sync.json
 filename:sftp.json path:.vscode
 filename:WebServers.xml
 filename:jupyter_notebook_config.json
-
+"https://hooks.slack.com/services/"


### PR DESCRIPTION
- Search URL: https://github.com/search?q=%22https%3A%2F%2Fhooks.slack.com%2Fservices%2F%22
- Number of search results at time of PR: 60,291
- Impact of data disclosed: High
- Description of data disclosed: Slack Key