### PR TITLE
Add GitHub, GitLab and Discord recovery codes (Hacktoberfest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,6 @@ filename:.remote-sync.json                      | Created by remote-sync for Ato
 filename:sftp.json path:.vscode                 | Created by vscode-sftp for VSCode, contains SFTP/SSH server details and credentails
 filename:sftp-config.json                       | Created by SFTP for Sublime Text, contains FTP/FTPS or SFTP/SSH server details and credentials
 filename:WebServers.xml                         | Created by Jetbrains IDEs, contains webserver credentials with encoded passwords ([not encrypted!](https://intellij-support.jetbrains.com/hc/en-us/community/posts/207074025/comments/207034775))
+filename:github-recovery-codes.txt              | GitHub recovery key
+filename:gitlab-recovery-codes.txt              | GitLab recovery key
+filename:discord_backup_codes.txt               | Discord recovery key

--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -80,4 +80,6 @@ filename:.remote-sync.json
 filename:sftp.json path:.vscode
 filename:WebServers.xml
 filename:jupyter_notebook_config.json
-
+filename:github-recovery-codes.txt
+filename:gitlab-recovery-codes.txt
+filename:discord_backup_codes.txt


### PR DESCRIPTION
- Search URLs:
  - https://github.com/search?q=filename%3Agithub-recovery-codes.txt
  - https://github.com/search?q=filename%3Agitlab-recovery-codes.txt
  - https://github.com/search?q=filename%3Adiscord_backup_codes.txt
- Number of search results at time of PR: 175
- Impact of data disclosed: High
- Description of data disclosed: Recovery codes
