### PR TITLE
add `cloud.redislabs.com` url in yaml/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,5 @@ filename:.remote-sync.json                      | Created by remote-sync for Ato
 filename:sftp.json path:.vscode                 | Created by vscode-sftp for VSCode, contains SFTP/SSH server details and credentails
 filename:sftp-config.json                       | Created by SFTP for Sublime Text, contains FTP/FTPS or SFTP/SSH server details and credentials
 filename:WebServers.xml                         | Created by Jetbrains IDEs, contains webserver credentials with encoded passwords ([not encrypted!](https://intellij-support.jetbrains.com/hc/en-us/community/posts/207074025/comments/207034775))
+extension:yaml cloud.redislabs.com              | Redis credentials provided by Redis Labs found in a YAML file
+extension:json cloud.redislabs.com              | Redis credentials provided by Redis Labs found in a JSON file

--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -80,4 +80,5 @@ filename:.remote-sync.json
 filename:sftp.json path:.vscode
 filename:WebServers.xml
 filename:jupyter_notebook_config.json
-
+extension:yaml cloud.redislabs.com
+extension:json cloud.redislabs.com


### PR DESCRIPTION
- Search URLs:
     - https://github.com/search?q=extension%3Ayaml+cloud.redislabs.com
     - https://github.com/search?q=extension%3Ajson+cloud.redislabs.com
- Number of search results at time of PR: 222
- Impact of data disclosed: High
- Description of data disclosed: Redis provided by Redis Labs w/ url `cloud.redislabs.com`