### PR TITLE
Add setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This tool uses [github3.py](https://github.com/sigmavirus24/github3.py) to talk 
 Clone this repository and run:
 
 ```shell
-pip install -r requirements.txt
+pip install .
 ```
 
 ### Usage
@@ -28,17 +28,17 @@ GH_URL   - Environment variable to specify GitHub Enterprise base URL
 Some example usages are listed below:
 
 ```shell
-python github-dork.py -r techgaun/github-dorks                          # search a single repo
+github-dork.py -r techgaun/github-dorks                          # search a single repo
 
-python github-dork.py -u techgaun                                       # search all repos of a user
+github-dork.py -u techgaun                                       # search all repos of a user
 
-python github-dork.py -u dev-nepal                                      # search all repos of an organization
+github-dork.py -u dev-nepal                                      # search all repos of an organization
 
-GH_USER=techgaun GH_PWD=<mypass> python github-dork.py -u dev-nepal     # search as authenticated user
+GH_USER=techgaun GH_PWD=<mypass> github-dork.py -u dev-nepal     # search as authenticated user
 
-GH_TOKEN=<github_token> python github-dork.py -u dev-nepal              # search using auth token
+GH_TOKEN=<github_token> github-dork.py -u dev-nepal              # search using auth token
 
-GH_URL=https://github.example.com python github-dork.py -u dev-nepal    # search a GitHub Enterprise instance
+GH_URL=https://github.example.com github-dork.py -u dev-nepal    # search a GitHub Enterprise instance
 ```
 
 ### Limitations

--- a/github-dork.py
+++ b/github-dork.py
@@ -7,7 +7,7 @@ import argparse
 import time
 import feedparser
 from copy import copy
-from sys import stderr
+from sys import stderr, prefix
 
 gh_user = os.getenv('GH_USER', None)
 gh_pass = os.getenv('GH_PWD', None)
@@ -87,7 +87,12 @@ def search(repo_to_search=None,
            output_filename=None):
 
     if gh_dorks_file is None:
-        gh_dorks_file = 'github-dorks.txt'
+        for path_prefix in ['.', os.path.join(prefix, 'github-dorks/')]:
+            filename = os.path.join(path_prefix, 'github-dorks.txt')
+            if os.path.isfile(filename):
+                gh_dorks_file = filename
+                break
+
     if not os.path.isfile(gh_dorks_file):
         raise Exception('Error, the dorks file path is not valid')
     if user_to_search:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
+setup(
+    name='github-dorks',
+    version='0.1',
+    description='Find leaked secrets via github search.',
+    license='Apache License 2.0',
+    long_description=long_description,
+    author='Samar Dhwoj Acharya (@techgaun)',
+    long_description_content_type='text/markdown',
+    scripts=['github-dork.py'],
+    data_files=[('github-dorks', ['github-dorks.txt'])],
+    install_requires=[
+        'github3.py==1.0.0a2',
+        'feedparser==6.0.2',
+    ],
+)


### PR DESCRIPTION
This PR adds a `setup.py` file to allow users to install github-dorks more easily. It also prepares for a CI/CD pipeline which pushes the package to pypi, so that this script could be installed with `pip install github-dorks`.

Also, the config file `github-dorks.txt` is currently only found if it's in the current directory. This PR contains a commit which adds logic so that a `github-dorks.txt` file installed by `pip` is also found.