### PR TITLE
chore(ci): add flake8 lint workflow and fix minor lint issue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint (flake8)
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install flake8
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+
+      - name: Run flake8
+        run: |
+          flake8 .

--- a/github-dork.py
+++ b/github-dork.py
@@ -28,7 +28,7 @@ def search_wrapper(gen):
             yield next(gen)
         except StopIteration:
             return
-        except github.exceptions.ForbiddenError as e:
+        except github.exceptions.ForbiddenError:
             search_rate_limit = gh.rate_limit()['resources']['search']
             # limit_remaining = search_rate_limit['remaining']
             reset_time = search_rate_limit['reset']


### PR DESCRIPTION
This PR adds flake8 as a CI lint job and includes a small code fix to ensure lint passes.

Changes:
- Add .github/workflows/lint.yml to run flake8 on push and pull_request using Python 3.8, matching the Dockerfile base image.
- Fix an unused exception variable in github-dork.py to satisfy flake8.

Notes:
- The repository already defines flake8 settings in setup.cfg (max-line-length=120), which the workflow respects.
- No functional behavior changed; only lint improvements and CI setup.

Resolves: #59